### PR TITLE
Fix PD3 errors and implement new instructions

### DIFF
--- a/project/pd3/design/code/branch_control.sv
+++ b/project/pd3/design/code/branch_control.sv
@@ -31,17 +31,22 @@ module branch_control #(
     output logic brlt_o
 );
 
-	always_comb begin
-		breq_o = 0;
-		brlt_o = 0;
+	// always_comb begin
+	// 	breq_o = 0;
+	// 	brlt_o = 0;
 
-		if (opcode_i == BTYPE_OPCODE) begin
-			unique case (funct3_i)
-				BREQ_FUNCT3: breq_o = rs1_i == rs2_i;
-				BRLT_FUNCT3: brlt_o = signed'(rs1_i) < signed'(rs2_i);
-			endcase
-		end
-	end
+	// 	if (opcode_i == BTYPE_OPCODE) begin
+	// 		breq_o = rs1_i == rs2_i;
+	// 		brlt_o = (funct3_i == BLTU_FUNCT3 || funct3_i == BGEU_FUNCT3)
+	// 			? rs1_i < rs2_i
+	// 			: signed'(rs1_i) < signed'(rs2_i);
+	// 	end
+	// end
+
+	assign breq_o = rs1_i == rs2_i;
+	assign brlt_o = (funct3_i == BLTU_FUNCT3 || funct3_i == BGEU_FUNCT3) 
+		? rs1_i < rs2_i 
+		: signed'(rs1_i) < signed'(rs2_i);
 
 endmodule : branch_control
 

--- a/project/pd3/design/code/constants.svh
+++ b/project/pd3/design/code/constants.svh
@@ -32,7 +32,9 @@ parameter logic [3:0] ALU_XOR = 4'b0100;
 parameter logic [3:0] ALU_SLL = 4'b0101;
 parameter logic [3:0] ALU_SRL = 4'b0110;
 parameter logic [3:0] ALU_SRA = 4'b0111;
-parameter logic [3:0] ALU_PASS = 4'b1000;
+parameter logic [3:0] ALU_SLT = 4'b1000;
+parameter logic [3:0] ALU_SLTU = 4'b1001;
+parameter logic [3:0] ALU_PASS = 4'b1010;
 
 // Writeback Select
 parameter logic [1:0] WB_ALU = 2'b00;

--- a/project/pd3/design/code/constants.svh
+++ b/project/pd3/design/code/constants.svh
@@ -41,8 +41,12 @@ parameter logic [1:0] WB_ALU = 2'b00;
 parameter logic [1:0] WB_MEM = 2'b01;
 parameter logic [1:0] WB_PC = 2'b10;
 
-// Branch funct3 codes
-parameter logic [2:0] BREQ_FUNCT3 = 3'b000;
-parameter logic [2:0] BRLT_FUNCT3 = 3'b100;
+// Branch instruction funct3 codes
+parameter logic [2:0] BEQ_FUNCT3 = 3'h0;
+parameter logic [2:0] BNE_FUNCT3 = 3'h1;
+parameter logic [2:0] BLT_FUNCT3 = 3'h4;
+parameter logic [2:0] BGE_FUNCT3 = 3'h5;
+parameter logic [2:0] BLTU_FUNCT3 = 3'h6;
+parameter logic [2:0] BGEU_FUNCT3 = 3'h7;
 
 `endif

--- a/project/pd3/design/code/control.sv
+++ b/project/pd3/design/code/control.sv
@@ -77,6 +77,8 @@ module control #(
                     3'b100: alusel_o = ALU_XOR;
                     3'b001: alusel_o = ALU_SLL;
                     3'b101: alusel_o = (funct7_i[5]) ? ALU_SRA : ALU_SRL; // SRA or SRL
+                    3'b010: alusel_o = ALU_SLT;
+                    3'b011: alusel_o = ALU_SLTU;
                     default: alusel_o = ALU_ADD;
                 endcase
             end
@@ -97,6 +99,8 @@ module control #(
                     3'b100: alusel_o = ALU_XOR; // XORI
                     3'b001: alusel_o = ALU_SLL; // SLLI
                     3'b101: alusel_o = (funct7_i[5]) ? ALU_SRA : ALU_SRL; // SRAI / SRLI
+                    3'b010: alusel_o = ALU_SLT;
+                    3'b011: alusel_o = ALU_SLTU;
                     default: alusel_o = ALU_ADD;
                 endcase
             end

--- a/project/pd3/design/code/control.sv
+++ b/project/pd3/design/code/control.sv
@@ -133,6 +133,8 @@ module control #(
                 pcsel_o   = 1;       // Control chooses branch target
                 regwren_o = 0;
                 immsel_o  = 1;
+                rs1sel_o  = 1;
+                rs2sel_o  = 1;
                 alusel_o  = ALU_ADD; // ALU add PC + offset
             end
 
@@ -141,20 +143,48 @@ module control #(
             // =====================================================
             JTYPE_OPCODE: begin
                 pcsel_o   = 1;
-                regwren_o = 1;
+                regwren_o = 1;       // rd <- PC+4
                 immsel_o  = 1;
-                wbsel_o   = WB_PC; // Write back PC+4 to register file
+                rs1sel_o  = 1;
+                rs2sel_o  = 1;
+                wbsel_o   = WB_PC;   // Write back PC+4 to register file
+                alusel_o  = ALU_ADD; // Compute target address PC + immediate offset
             end
+
+            // =====================================================
+			// JALR
+			// =====================================================
+			JALR_OPCODE: begin
+				pcsel_o   = 1;
+				regwren_o = 1;       // rd <- PC+4
+				immsel_o  = 1;
+				rs2sel_o  = 1;       // Use immediate for target address calculation
+				wbsel_o   = WB_PC;   // Write back PC+4 to register file
+				alusel_o  = ALU_ADD; // Compute target address rs1 + immediate offset
+			end
 
             // =====================================================
             // LUI
             // =====================================================
             LUI_OPCODE: begin
                 regwren_o = 1;
-                immsel_o  = 1;
+                immsel_o  = 1;        // Use sign-extended 20-bit U-immediate
+                rs2sel_o  = 1;
                 wbsel_o   = WB_ALU;
                 alusel_o  = ALU_PASS; // Pass immediate from ALU
             end
+
+			// =====================================================
+			// AUIPC
+			// =====================================================
+			AUIPC_OPCODE: begin
+				regwren_o = 1;
+				immsel_o  = 1;       // Use sign-extended 20-bit U-immediate
+                rs1sel_o  = 1;       // Use PC as rs1
+                rs2sel_o  = 1;
+				wbsel_o   = WB_ALU;  // Write back PC + immediate to register file
+				alusel_o  = ALU_ADD; // PC + immediate
+			end
         endcase
     end
 	

--- a/project/pd3/design/code/decode.sv
+++ b/project/pd3/design/code/decode.sv
@@ -71,18 +71,23 @@ module decode #(
 		funct7_o = insn_i[31:25];
 		shamt_o  = insn_i[24:20];
 
+		// After running tests, we determined that there is
+		// no need to clear unused fields since control signals
+		// determine how the decoded data is to be interpreted anyways.
+		// Clearing unused fields also led to the pattern check tests failing.
+
 		// Clear unused instruction fields based on instruction type
-		if (is_stype || is_btype) begin
-			// rd_o     = 5'b0;
-			// funct7_o = 7'b0;
-		end else if (is_itype) begin
-			// rs2_o    = 5'b0;
-			// funct7_o = 7'b0;
-		end else if (is_utype || is_jtype) begin
-			rs1_o    = 5'b0;
-			rs2_o    = 5'b0;
-			funct7_o = 7'b0;
-		end
+		// if (is_stype || is_btype) begin
+		// 	// rd_o     = 5'b0;
+		// 	// funct7_o = 7'b0;
+		// end else if (is_itype) begin
+		// 	// rs2_o    = 5'b0;
+		// 	// funct7_o = 7'b0;
+		// end else if (is_utype || is_jtype) begin
+		// 	// rs1_o    = 5'b0;
+		// 	// rs2_o    = 5'b0;
+		// 	// funct7_o = 7'b0;
+		// end
 	end
 
 endmodule : decode

--- a/project/pd3/design/code/decode.sv
+++ b/project/pd3/design/code/decode.sv
@@ -73,11 +73,11 @@ module decode #(
 
 		// Clear unused instruction fields based on instruction type
 		if (is_stype || is_btype) begin
-			rd_o     = 5'b0;
-			funct7_o = 7'b0;
+			// rd_o     = 5'b0;
+			// funct7_o = 7'b0;
 		end else if (is_itype) begin
-			rs2_o    = 5'b0;
-			funct7_o = 7'b0;
+			// rs2_o    = 5'b0;
+			// funct7_o = 7'b0;
 		end else if (is_utype || is_jtype) begin
 			rs1_o    = 5'b0;
 			rs2_o    = 5'b0;

--- a/project/pd3/design/code/execute.sv
+++ b/project/pd3/design/code/execute.sv
@@ -44,9 +44,9 @@ module alu #(
 			ALU_AND: res_o = rs1_i & rs2_i;
 			ALU_OR: res_o = rs1_i | rs2_i;
 			ALU_XOR: res_o = rs1_i ^ rs2_i;
-			ALU_SLL: res_o = rs1_i << rs2_i;
-			ALU_SRL: res_o = rs1_i >> rs2_i;
-			ALU_SRA: res_o = rs1_i >>> rs2_i;
+			ALU_SLL: res_o = rs1_i << rs2_i[4:0];
+			ALU_SRL: res_o = rs1_i >> rs2_i[4:0];
+			ALU_SRA: res_o = rs1_i >>> rs2_i[4:0];
             ALU_SLT: res_o = signed'(rs1_i) < signed'(rs2_i);
             ALU_SLTU: res_o = rs1_i < rs2_i;
 			ALU_PASS: res_o = rs2_i;

--- a/project/pd3/design/code/execute.sv
+++ b/project/pd3/design/code/execute.sv
@@ -39,7 +39,9 @@ module alu #(
 		res_o = 0;
 
 		unique case (alusel_i)
-			ALU_ADD: res_o = rs1_i + rs2_i;
+			ALU_ADD: res_o = (opcode_i == JALR_OPCODE) 
+				? (rs1_i + rs2_i) & 32'hFFFFFFFE
+				: rs1_i + rs2_i;
 			ALU_SUB: res_o = rs1_i - rs2_i;
 			ALU_AND: res_o = rs1_i & rs2_i;
 			ALU_OR: res_o = rs1_i | rs2_i;

--- a/project/pd3/design/code/execute.sv
+++ b/project/pd3/design/code/execute.sv
@@ -47,6 +47,8 @@ module alu #(
 			ALU_SLL: res_o = rs1_i << rs2_i;
 			ALU_SRL: res_o = rs1_i >> rs2_i;
 			ALU_SRA: res_o = rs1_i >>> rs2_i;
+            ALU_SLT: res_o = signed'(rs1_i) < signed'(rs2_i);
+            ALU_SLTU: res_o = rs1_i < rs2_i;
 			ALU_PASS: res_o = rs2_i;
 		endcase
 	end

--- a/project/pd3/design/code/execute.sv
+++ b/project/pd3/design/code/execute.sv
@@ -39,7 +39,7 @@ module alu #(
 		res_o = 0;
 
 		unique case (alusel_i)
-			ALU_ADD: res_o = (opcode_i == BTYPE_OPCODE ? pc_i : rs1_i) + rs2_i;
+			ALU_ADD: res_o = rs1_i + rs2_i;
 			ALU_SUB: res_o = rs1_i - rs2_i;
 			ALU_AND: res_o = rs1_i & rs2_i;
 			ALU_OR: res_o = rs1_i | rs2_i;

--- a/project/pd3/design/code/pd3.sv
+++ b/project/pd3/design/code/pd3.sv
@@ -10,6 +10,8 @@
  * 2) reset signal
  */
 
+`include "constants.svh"
+
 module pd3 #(
     parameter int AWIDTH = 32,
     parameter int DWIDTH = 32

--- a/project/pd3/design/code/pd3.sv
+++ b/project/pd3/design/code/pd3.sv
@@ -167,17 +167,19 @@ module pd3 #(
 	logic r_write_enable;
 	logic [4:0] r_read_rs1;
 	logic [4:0] r_read_rs2;
+    logic [4:0] r_write_destination;
+    logic [DWIDTH-1:0] r_write_data;
 	logic [DWIDTH-1:0] r_read_rs1_data;
 	logic [DWIDTH-1:0] r_read_rs2_data;
 
 	register_file #(.DWIDTH(DWIDTH)) e_register_file (
 		.clk(clk),
 		.rst(reset),
-		.rs1_i (d_rs1),
-		.rs2_i (d_rs2),
-		.rd_i (d_rd),
+		.rs1_i (r_read_rs1),
+		.rs2_i (r_read_rs2),
+		.rd_i (r_write_destination),
 		.datawb_i (wb_data),
-		.regwren_i (regwren_out),
+		.regwren_i (r_write_enable),
 
 		.rs1data_o (r_read_rs1_data),
 		.rs2data_o (r_read_rs2_data)
@@ -185,6 +187,9 @@ module pd3 #(
 
 	assign r_read_rs1 = d_rs1;
 	assign r_read_rs2 = d_rs2;
+    assign r_write_destination = d_rd;
+    assign r_write_enable = regwren_out;
+    assign r_write_data = 0;
 
 	// ---------------------------------------------------------
 	// ALU

--- a/project/pd3/design/code/pd3.sv
+++ b/project/pd3/design/code/pd3.sv
@@ -232,8 +232,26 @@ module pd3 #(
 		.brlt_o (brlt_o)
 	);
 
+	always_comb begin : branch_taken_logic
+		e_br_taken = 0;
+		if (d_opcode == BTYPE_OPCODE) begin
+			unique case (d_funct3)
+				BEQ_FUNCT3: e_br_taken = breq_o;
+				BNE_FUNCT3: e_br_taken = ~breq_o;
+				
+				BLT_FUNCT3,
+				BLTU_FUNCT3: e_br_taken = brlt_o;
+				
+				BGE_FUNCT3,
+				BGEU_FUNCT3: e_br_taken = ~brlt_o;
+				
+				default: e_br_taken = 0;
+			endcase
+		end
+	end
+
 	assign e_pc = d_pc;
-	assign e_br_taken = breq_o | brlt_o;
+	// assign e_br_taken = breq_o | brlt_o;
 
 	// ---------------------------------------------------------
 	// Writeback Multiplexer 

--- a/project/pd3/design/code/pd3.sv
+++ b/project/pd3/design/code/pd3.sv
@@ -195,14 +195,14 @@ module pd3 #(
 
 	logic e_br_taken;
 	logic [AWIDTH-1:0] e_pc;
-	logic [DWIDTH-1:0] e_op2, e_alu_res;
+	logic [DWIDTH-1:0] e_op1, e_op2, e_alu_res;
 
 	alu #(
 		.DWIDTH(DWIDTH), 
 		.AWIDTH(AWIDTH)
 	) e_alu (
 		.pc_i (f_pc),
-		.rs1_i (r_read_rs1_data),
+		.rs1_i (e_op1),
 		.rs2_i (e_op2),
 		.opcode_i (d_opcode),
 		.funct3_i (d_funct3),
@@ -213,6 +213,7 @@ module pd3 #(
 		.brtaken_o (e_br_taken)
 	);
 
+    assign e_op1 = rs1sel_out ? f_pc : r_read_rs1_data;
 	assign e_op2 = immsel_out ? d_imm : r_read_rs2_data;
 
 	// ---------------------------------------------------------

--- a/project/pd3/design/code/pd3.sv
+++ b/project/pd3/design/code/pd3.sv
@@ -25,14 +25,14 @@ module pd3 #(
 	// The instruction memory is pre-loaded with machine code.
 
 	// imemory signals
-	logic [DWIDTH - 1:0] addr_i;
-	logic [DWIDTH - 1:0] data_i;
+	logic [DWIDTH-1:0] addr_i;
+	logic [DWIDTH-1:0] data_i;
 	logic write_en;
 	logic read_en;
 		
 	// Fetch signals
-	logic [DWIDTH - 1:0] f_pc;
-	logic [DWIDTH - 1:0] f_insn;
+	logic [DWIDTH-1:0] f_pc;
+	logic [DWIDTH-1:0] f_insn;
 		
 	memory #(
 		.AWIDTH(AWIDTH),
@@ -98,7 +98,7 @@ module pd3 #(
 		.pc_i (f_pc),
 
 		.pc_o (d_pc),
-		.insn_o (f_insn),
+		.insn_o (d_insn),
 		.opcode_o (d_opcode),
 		.rd_o (d_rd),
 		.rs1_o (d_rs1),
@@ -162,8 +162,6 @@ module pd3 #(
 	// Register File
 	// ---------------------------------------------------------
 
-	logic [DWIDTH-1:0] wb_data; // see writeback mux below, only for testing this pd
-
 	logic r_write_enable;
 	logic [4:0] r_read_rs1;
 	logic [4:0] r_read_rs2;
@@ -178,7 +176,7 @@ module pd3 #(
 		.rs1_i (r_read_rs1),
 		.rs2_i (r_read_rs2),
 		.rd_i (r_write_destination),
-		.datawb_i (wb_data),
+		.datawb_i (r_write_data),
 		.regwren_i (r_write_enable),
 
 		.rs1data_o (r_read_rs1_data),
@@ -242,17 +240,18 @@ module pd3 #(
 	// the register file, despite this PD not implementing write-back)
 	// ---------------------------------------------------------
 
-	logic [DWIDTH-1:0] pc_plus4;
+    // logic [DWIDTH-1:0] wb_data; // see writeback mux below, only for testing this pd
+	// logic [DWIDTH-1:0] pc_plus4;
 
-	assign pc_plus4 = f_pc + 32'd4;
+	// assign pc_plus4 = f_pc + 32'd4;
 
-	always_comb begin
-		unique case (wbsel_out)
-			2'b00: wb_data = e_alu_res;
-			2'b01: wb_data = f_insn;
-			2'b10: wb_data = e_br_taken ? e_alu_res : pc_plus4;
-			default: wb_data = '0;
-		endcase
-	end
+	// always_comb begin
+	// 	unique case (wbsel_out)
+	// 		2'b00: wb_data = e_alu_res;
+	// 		2'b01: wb_data = f_insn;
+	// 		2'b10: wb_data = e_br_taken ? e_alu_res : pc_plus4;
+	// 		default: wb_data = '0;
+	// 	endcase
+	// end
 
 endmodule : pd3


### PR DESCRIPTION
The mock write-back multiplexer we implemented for testing the register file was causing the PD3 pattern check tests to fail. It was supposed to be removed before the end of PD3, but was accidentally kept in. Additionally, the if statements used to clear unused instruction fields based on the instruction type as a safety precaution was also causing tests to fail, so it needed to be removed.

The following instructions were implemented in this pull request, since the test programs included them:
- lui
- auipc
- jal and jalr
- beq, bne, blt, bge, bltu, bgeu, slt(i), slt(i)u

The ALU and control signal module was also improved, and proper branch condition computation was implemented.